### PR TITLE
feat: add + New Chat button with left-aligned styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,13 @@
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">
+                <!-- New Chat Button -->
+                <div class="sidebar-section">
+                    <button class="new-chat-button" id="newChatButton">
+                        + New Chat
+                    </button>
+                </div>
+                
                 <!-- Course Stats -->
                 <div class="sidebar-section">
                     <details class="stats-collapsible">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -5,7 +5,7 @@ const API_URL = '/api';
 let currentSessionId = null;
 
 // DOM elements
-let chatMessages, chatInput, sendButton, totalCourses, courseTitles;
+let chatMessages, chatInput, sendButton, totalCourses, courseTitles, newChatButton;
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     sendButton = document.getElementById('sendButton');
     totalCourses = document.getElementById('totalCourses');
     courseTitles = document.getElementById('courseTitles');
+    newChatButton = document.getElementById('newChatButton');
     
     setupEventListeners();
     createNewSession();
@@ -29,6 +30,8 @@ function setupEventListeners() {
         if (e.key === 'Enter') sendMessage();
     });
     
+    // New Chat button
+    newChatButton.addEventListener('click', createNewSession);
     
     // Suggested questions
     document.querySelectorAll('.suggested-item').forEach(button => {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -601,6 +601,32 @@ details[open] .suggested-header::before {
     text-transform: none;
 }
 
+/* New Chat Button */
+.new-chat-button {
+    padding: 0.75rem 1rem;
+    background: var(--background);
+    border: none;
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: left;
+    width: 100%;
+    font-weight: 500;
+}
+
+.new-chat-button:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.new-chat-button:hover {
+    background: var(--surface-hover);
+    color: var(--primary-color);
+    transform: translateX(2px);
+}
+
 /* Suggested Questions in Sidebar */
 .suggested-items {
     display: flex;


### PR DESCRIPTION
This PR adds the missing + New Chat button to the sidebar with styling that matches the other links.

## Changes
- Added new chat button to the top of the left sidebar
- Styled with left alignment and no border to match Courses and Try Asking sections
- Connected to existing createNewSession() functionality
- Consistent hover effects and visual design

Fixes #3

Generated with [Claude Code](https://claude.ai/code)