### PR TITLE
feat: add '+ NEW CHAT' button to clear conversations

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,13 @@
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">
+                <!-- New Chat Button -->
+                <div class="sidebar-section">
+                    <button class="new-chat-button" id="newChatButton">
+                        + NEW CHAT
+                    </button>
+                </div>
+                
                 <!-- Course Stats -->
                 <div class="sidebar-section">
                     <details class="stats-collapsible">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -5,7 +5,7 @@ const API_URL = '/api';
 let currentSessionId = null;
 
 // DOM elements
-let chatMessages, chatInput, sendButton, totalCourses, courseTitles;
+let chatMessages, chatInput, sendButton, totalCourses, courseTitles, newChatButton;
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     sendButton = document.getElementById('sendButton');
     totalCourses = document.getElementById('totalCourses');
     courseTitles = document.getElementById('courseTitles');
+    newChatButton = document.getElementById('newChatButton');
     
     setupEventListeners();
     createNewSession();
@@ -27,6 +28,12 @@ function setupEventListeners() {
     sendButton.addEventListener('click', sendMessage);
     chatInput.addEventListener('keypress', (e) => {
         if (e.key === 'Enter') sendMessage();
+    });
+    
+    // New chat functionality
+    newChatButton.addEventListener('click', () => {
+        createNewSession();
+        chatInput.focus();
     });
     
     

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -445,6 +445,41 @@ header h1 {
     margin: 0.5rem 0;
 }
 
+/* New Chat Button */
+.new-chat-button {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    background: var(--background);
+    border-radius: 8px;
+    outline: none;
+    transition: all 0.2s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    width: 100%;
+    text-align: center;
+}
+
+.new-chat-button:focus {
+    color: var(--primary-color);
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.new-chat-button:hover {
+    color: var(--primary-color);
+    background: var(--surface-hover);
+    border-color: var(--primary-color);
+    transform: translateY(-1px);
+}
+
+.new-chat-button:active {
+    transform: translateY(0);
+}
+
 /* Sidebar Headers */
 .stats-header,
 .suggested-header {


### PR DESCRIPTION
Adds a '+ NEW CHAT' button to the left sidebar above the courses section. When clicked, it clears the current conversation and starts a new session without page reload.

## Changes
- Added new chat button to top of left sidebar
- Styled to match existing section headers (uppercase, same colors)
- Connected to existing session management system
- No backend changes needed

## Testing
The button properly:
- Clears current conversation
- Starts new session without page reload
- Matches existing UI styling and behavior

Fixes #2

Generated with [Claude Code](https://claude.ai/code)